### PR TITLE
Allow arrivals board cache to be bypassed

### DIFF
--- a/src/services/arrivals.js
+++ b/src/services/arrivals.js
@@ -80,13 +80,13 @@ function buildArrivalMap(feedEntities) {
  * Returns a humanized board for a stop, cached for 20m.
  * groupId: ACE | BDFM | G | JZ | NQRW | L | SI | 1234567
  */
-export async function getArrivalBoard(groupId, stopId) {
+export async function getArrivalBoard(groupId, stopId, { apiKey = null, useCache = true } = {}) {
   const key = `board:${groupId}`;
-  let board = getCache(key);
+  let board = useCache ? getCache(key) : null;
 
   if (!board) {
     // build fresh from feed and cache
-    const feed = await fetchFeed(groupId, { useCache: true });
+    const feed = await fetchFeed(groupId, { useCache, apiKey });
     const byStop = buildArrivalMap(feed);
     const { dict: stops } = await loadStops();
 
@@ -100,7 +100,7 @@ export async function getArrivalBoard(groupId, stopId) {
         arrivals,
       };
     }
-    setCache(key, board);
+    if (useCache) setCache(key, board);
   }
 
   // format the single stop response at request-time (updates “in 3m” labels)

--- a/src/services/mta.js
+++ b/src/services/mta.js
@@ -88,7 +88,7 @@ function formatTimestamp(ts) {
   try { return new Date(ts * 1000).toISOString(); } catch { return null; }
 }
 
-export async function fetchFeed(groupId, { useCache = true } = {}) {
+export async function fetchFeed(groupId, { useCache = true, apiKey: overrideApiKey = null } = {}) {
   const url = getGroupUrl(groupId);
   if (!url) throw new Error(`Unknown feed group: ${groupId}`);
 
@@ -98,7 +98,7 @@ export async function fetchFeed(groupId, { useCache = true } = {}) {
     if (c) return c;
   }
 
-  const apiKey = process.env.MTA_API_KEY;
+  const apiKey = overrideApiKey || process.env.MTA_API_KEY;
   const resp = await axios.get(url, {
     responseType: 'arraybuffer',
     headers: apiKey ? { 'x-api-key': apiKey } : undefined,
@@ -150,6 +150,6 @@ export async function fetchFeed(groupId, { useCache = true } = {}) {
     });
   }
 
-  setCache(cacheKey, result);
+  if (useCache) setCache(cacheKey, result);
   return result;
 }


### PR DESCRIPTION
## Summary
- allow the feed fetcher to accept a per-request API key and skip caching when disabled
- update the arrivals board service to respect cache bypass requests and use the provided API key

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e1c29736f083208beb9940bc276453