### PR TITLE
Add endpoint to list stops by route

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A tiny Express server that exposes NYC Subway GTFS-realtime data + static stops/
 
 - `GET /health` – quick check
 - `GET /v1/routes` – list routes from `data/routes.txt`
+- `GET /v1/routes/:routeId/stops` – stops serving a specific route (alphabetically sorted)
 - `GET /v1/stops?query=Times%20Sq&route=N` – search stops by name/ID; optionally filter by a route letter
 - `GET /v1/stops/:stopId` – single stop by ID (e.g., `R16N`)
 - `GET /v1/feed` – list available feed *groups* (`ACE`, `BDFM`, `G`, `JZ`, `NQRW`, `L`, `SI`, `1234567`)
@@ -15,6 +16,25 @@ Example:
 ```
 curl -H "x-api-key: $MTA_API_KEY" "http://localhost:3000/v1/feed/NQRW"
 ```
+
+### `GET /v1/routes/:routeId/stops`
+
+Returns the list of stops whose `routes` field contains the requested `routeId`. The results are sorted alphabetically by stop name (and by stop ID as a tiebreaker). A typical response looks like:
+
+```json
+[
+  {
+    "id": "R16N",
+    "name": "Times Sq-42 St",
+    "lat": 40.75529,
+    "lon": -73.987495,
+    "routes": "N Q R W",
+    "parent": "R16"
+  }
+]
+```
+
+If no stops match the provided `routeId`, an empty array is returned. Requesting the endpoint without a `routeId` yields a `400` error response.
 
 > NOTE: If you set `MTA_API_KEY` in `.env`, you don't need to pass the header; the server will include it automatically.
 

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { loadRoutes } from '../services/mta.js';
+import { loadRoutes, loadStops } from '../services/mta.js';
 
 const router = Router();
 
@@ -7,6 +7,33 @@ router.get('/', async (req, res, next) => {
   try {
     const { list } = await loadRoutes();
     res.json(list);
+  } catch (e) { next(e); }
+});
+
+router.get('/:routeId/stops', async (req, res, next) => {
+  try {
+    const routeIdRaw = (req.params.routeId || '').toString().trim();
+    if (!routeIdRaw) {
+      return res.status(400).json({ error: 'Route ID is required' });
+    }
+
+    const routeId = routeIdRaw.toUpperCase();
+    const { dict } = await loadStops();
+
+    const stops = Object.values(dict).filter(stop => {
+      const routes = (stop.routes || '').toString().toUpperCase();
+      if (!routes) return false;
+      const tokens = routes.split(/[^A-Z0-9]+/).filter(Boolean);
+      return tokens.includes(routeId) || routes.includes(routeId);
+    });
+
+    stops.sort((a, b) => {
+      const nameCompare = (a.name || '').localeCompare(b.name || '', 'en', { sensitivity: 'base' });
+      if (nameCompare !== 0) return nameCompare;
+      return (a.id || '').localeCompare(b.id || '', 'en', { sensitivity: 'base' });
+    });
+
+    res.json(stops);
   } catch (e) { next(e); }
 });
 


### PR DESCRIPTION
## Summary
- add a new `/v1/routes/:routeId/stops` handler that filters stops by the requested route and sorts them alphabetically
- document the route stop lookup endpoint and response format in the README

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e1cd2f6fe48320ad0a9c2c430d4ac1